### PR TITLE
Fix Maven build issue.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<dependency>
 			<groupId>com.github.ptgoetz</groupId>
 			<artifactId>stemshell</artifactId>
-			<version>0.1.0-SNAPSHOT</version>
+			<version>0.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Reference stemshell version 0.1.0 instead of 0.1.0-SNAPSHOT.  Fixes #4
